### PR TITLE
Fix crypto polyfill on Node 20

### DIFF
--- a/src/index.node.mjs
+++ b/src/index.node.mjs
@@ -1,3 +1,13 @@
-import { webcrypto as crypto } from 'crypto'
-global.crypto = crypto
+import { webcrypto } from 'crypto'
+
+if (!global.crypto) {
+  Object.defineProperty(global, 'crypto', {
+    get() {
+      return webcrypto
+    },
+    enumerable: true,
+    configurable: true,
+  })
+}
+
 export * from './index.js'


### PR DESCRIPTION
There is an error in Node 20 error when trying to set `crypto` property on `global`.

```
TypeError: Cannot set property crypto of #<Object> which has only a getter
```

This PR adds a condition before applying the polyfill. It also makes it match the original in terms of descriptors. 

I don't know what to do with `enumerable`. It's `true` on Node 20 but `false` on earlier ones.

![image](https://github.com/ValeriaVG/xksuid/assets/7079786/35134f21-2bc4-4c0b-9ad6-679dcfea47d7)

![image](https://github.com/ValeriaVG/xksuid/assets/7079786/c241d12d-1e8b-4ef8-82d6-dfe3cb1ae639)
